### PR TITLE
runが走るようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '4.2.5'
+gem 'rails', '4.2.8'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
 # Use SCSS for stylesheets


### PR DESCRIPTION
railsとrubyのバージョンの組み合わせによって、起動時に無限ループが起きるみたい。

ref: https://stackoverflow.com/questions/41504106/ruby-2-4-and-rails-4-stack-level-too-deep-systemstackerror

この状態にして、`bundle install` もしくは`bundle update`したらrunが動きました